### PR TITLE
Update api in client-go

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module istio.io/client-go
 go 1.16
 
 require (
-	istio.io/api v0.0.0-20210711222728-b04257312323
+	istio.io/api v0.0.0-20210713184933-b719f46511e4
 	k8s.io/apimachinery v0.21.0
 	k8s.io/client-go v0.21.0
 )

--- a/go.sum
+++ b/go.sum
@@ -433,8 +433,8 @@ honnef.co/go/tools v0.0.0-20190418001031-e561f6794a2a/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWhAfAdb/ePZxsR/4RtNHQocxwk9r4=
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-istio.io/api v0.0.0-20210711222728-b04257312323 h1:bpi1nm4Cva+4DNAMFxXNoSkGY5DozqnnF0dqroyQrpo=
-istio.io/api v0.0.0-20210711222728-b04257312323/go.mod h1:nsSFw1LIMmGL7r/+6fJI6FxeG/UGlLxRK8bkojIvBVs=
+istio.io/api v0.0.0-20210713184933-b719f46511e4 h1:gtWnt+NoVcpIMubFwmDfNuo/qhLf0v4q8l22V9LJ6JI=
+istio.io/api v0.0.0-20210713184933-b719f46511e4/go.mod h1:nsSFw1LIMmGL7r/+6fJI6FxeG/UGlLxRK8bkojIvBVs=
 istio.io/gogo-genproto v0.0.0-20210113155706-4daf5697332f h1:9710FpGLvIJ1GGEbpuTh1smVBv+r8cJfR3G82ouSxIQ=
 istio.io/gogo-genproto v0.0.0-20210113155706-4daf5697332f/go.mod h1:6BwTZRNbWS570wHX/uR1Wqk5e0157TofTAUMzT7N4+s=
 k8s.io/api v0.20.2/go.mod h1:d7n6Ehyzx+S+cE3VhTGfVNNqtGc/oL9DCdYYahlurV8=


### PR DESCRIPTION
Add back the update of api in client-go, even in the case of a `common-files` change. This means that the non-update fro common-files updates will only happen in the istio/istio repo and would be picked up in an update_deps.sh.

I will add the automated job back into test-infra so this is done automatically.