### PR TITLE
Manually update to latest istio/api

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module istio.io/client-go
 go 1.18
 
 require (
-	istio.io/api v0.0.0-20230306190845-6bbcb3e795fa
+	istio.io/api v0.0.0-20230306191145-5e59387fbd49
 	k8s.io/apimachinery v0.26.0
 	k8s.io/client-go v0.26.0
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3

--- a/go.sum
+++ b/go.sum
@@ -461,8 +461,6 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-istio.io/api v0.0.0-20230306190845-6bbcb3e795fa h1:EJmiK50Ikf9OXJjTe+26Hp/+vjGn/Hpv/VVmmhTMdUs=
-istio.io/api v0.0.0-20230306190845-6bbcb3e795fa/go.mod h1:q3bvmBQjuI+OKNn9693bhGq3Pk+rECjfs3OpPWInHY0=
 istio.io/api v0.0.0-20230306191145-5e59387fbd49 h1:JJGkcRk1xBrvP0U9hmbKEek+JT8QUtpBwxkLvRA7K7k=
 istio.io/api v0.0.0-20230306191145-5e59387fbd49/go.mod h1:q3bvmBQjuI+OKNn9693bhGq3Pk+rECjfs3OpPWInHY0=
 k8s.io/api v0.26.0 h1:IpPlZnxBpV1xl7TGk/X6lFtpgjgntCg8PJ+qrPHAC7I=

--- a/go.sum
+++ b/go.sum
@@ -463,6 +463,8 @@ honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 istio.io/api v0.0.0-20230306190845-6bbcb3e795fa h1:EJmiK50Ikf9OXJjTe+26Hp/+vjGn/Hpv/VVmmhTMdUs=
 istio.io/api v0.0.0-20230306190845-6bbcb3e795fa/go.mod h1:q3bvmBQjuI+OKNn9693bhGq3Pk+rECjfs3OpPWInHY0=
+istio.io/api v0.0.0-20230306191145-5e59387fbd49 h1:JJGkcRk1xBrvP0U9hmbKEek+JT8QUtpBwxkLvRA7K7k=
+istio.io/api v0.0.0-20230306191145-5e59387fbd49/go.mod h1:q3bvmBQjuI+OKNn9693bhGq3Pk+rECjfs3OpPWInHY0=
 k8s.io/api v0.26.0 h1:IpPlZnxBpV1xl7TGk/X6lFtpgjgntCg8PJ+qrPHAC7I=
 k8s.io/api v0.26.0/go.mod h1:k6HDTaIFC8yn1i6pSClSqIwLABIcLV9l5Q4EcngKnQg=
 k8s.io/apimachinery v0.26.0 h1:1feANjElT7MvPqp0JT6F3Ss6TWDwmcjLypwoPpEf7zg=


### PR DESCRIPTION
I'm not sure what the root cause of the failures in the latest automated update jobs, but it seems to not be able to do a `go get` against istio/api if the full sha is used, but works fine with the shorter sha or using the branch:
```
> go get istio.io/api@5e59387fbd49                                                                                                                                  
go: upgraded istio.io/api v0.0.0-20230306190845-6bbcb3e795fa => v0.0.0-20230306191145-5e59387fbd49
> go get istio.io/api@5e59387fbd4989c96ebb6e129eafd303e28b5b47
go: istio.io/api@5e59387fbd4989c96ebb6e129eafd303e28b5b47: unrecognized import path "istio.io/api": reading https://istio.io/api?go-get=1: 404 Not Found
```
As the automation is failing, here is a manual update.