### PR TITLE
Manual update of istio/api (pipeline is failing)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module istio.io/client-go
 go 1.18
 
 require (
-	istio.io/api v0.0.0-20230410062459-60a4392c3fd9
+	istio.io/api v0.0.0-20230410230800-a94614182296
 	k8s.io/apimachinery v0.26.0
 	k8s.io/client-go v0.26.0
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3

--- a/go.sum
+++ b/go.sum
@@ -461,8 +461,8 @@ honnef.co/go/tools v0.0.0-20190523083050-ea95bdfd59fc/go.mod h1:rf3lG4BRIbNafJWh
 honnef.co/go/tools v0.0.1-2019.2.3/go.mod h1:a3bituU0lyd329TUQxRnasdCoJDkEUEAqEt0JzvZhAg=
 honnef.co/go/tools v0.0.1-2020.1.3/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
 honnef.co/go/tools v0.0.1-2020.1.4/go.mod h1:X/FiERA/W4tHapMX5mGpAtMSVEeEUOyHaw9vFzvIQ3k=
-istio.io/api v0.0.0-20230410062459-60a4392c3fd9 h1:i7ZFNXcxjMwEgAY5NR+3AIGPbf2F6QBNmqJU5stsKvg=
-istio.io/api v0.0.0-20230410062459-60a4392c3fd9/go.mod h1:q3bvmBQjuI+OKNn9693bhGq3Pk+rECjfs3OpPWInHY0=
+istio.io/api v0.0.0-20230410230800-a94614182296 h1:ZpBwDPGZZ16Vq3YYYtRg6dR7pbmSl0c2wA91kEQRHqg=
+istio.io/api v0.0.0-20230410230800-a94614182296/go.mod h1:q3bvmBQjuI+OKNn9693bhGq3Pk+rECjfs3OpPWInHY0=
 k8s.io/api v0.26.0 h1:IpPlZnxBpV1xl7TGk/X6lFtpgjgntCg8PJ+qrPHAC7I=
 k8s.io/api v0.26.0/go.mod h1:k6HDTaIFC8yn1i6pSClSqIwLABIcLV9l5Q4EcngKnQg=
 k8s.io/apimachinery v0.26.0 h1:1feANjElT7MvPqp0JT6F3Ss6TWDwmcjLypwoPpEf7zg=


### PR DESCRIPTION
The pipeline is failing to update istio/api due to a random `go get` failure. This PR is the manual equivalent.