### PR TITLE
ServiceEntryStatus make gen

### DIFF
--- a/pkg/apis/networking/v1/types.gen.go
+++ b/pkg/apis/networking/v1/types.gen.go
@@ -159,7 +159,7 @@ type ServiceEntry struct {
 	// +optional
 	Spec v1alpha3.ServiceEntry `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 
-	Status v1alpha1.IstioStatus `json:"status"`
+	Status v1alpha3.ServiceEntryStatus `json:"status"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/networking/v1alpha3/types.gen.go
+++ b/pkg/apis/networking/v1alpha3/types.gen.go
@@ -206,7 +206,7 @@ type ServiceEntry struct {
 	// +optional
 	Spec networkingv1alpha3.ServiceEntry `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 
-	Status v1alpha1.IstioStatus `json:"status"`
+	Status networkingv1alpha3.ServiceEntryStatus `json:"status"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/apis/networking/v1beta1/types.gen.go
+++ b/pkg/apis/networking/v1beta1/types.gen.go
@@ -206,7 +206,7 @@ type ServiceEntry struct {
 	// +optional
 	Spec v1alpha3.ServiceEntry `json:"spec,omitempty" protobuf:"bytes,2,opt,name=spec"`
 
-	Status v1alpha1.IstioStatus `json:"status"`
+	Status v1alpha3.ServiceEntryStatus `json:"status"`
 }
 
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object

--- a/pkg/applyconfiguration/networking/v1/serviceentry.go
+++ b/pkg/applyconfiguration/networking/v1/serviceentry.go
@@ -17,7 +17,6 @@
 package v1
 
 import (
-	v1alpha1 "istio.io/api/meta/v1alpha1"
 	v1alpha3 "istio.io/api/networking/v1alpha3"
 	v1 "istio.io/client-go/pkg/applyconfiguration/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,8 +28,8 @@ import (
 type ServiceEntryApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	Spec                             *v1alpha3.ServiceEntry `json:"spec,omitempty"`
-	Status                           *v1alpha1.IstioStatus  `json:"status,omitempty"`
+	Spec                             *v1alpha3.ServiceEntry       `json:"spec,omitempty"`
+	Status                           *v1alpha3.ServiceEntryStatus `json:"status,omitempty"`
 }
 
 // ServiceEntry constructs an declarative configuration of the ServiceEntry type for use with
@@ -213,7 +212,7 @@ func (b *ServiceEntryApplyConfiguration) WithSpec(value v1alpha3.ServiceEntry) *
 // WithStatus sets the Status field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Status field is set to the value of the last call.
-func (b *ServiceEntryApplyConfiguration) WithStatus(value v1alpha1.IstioStatus) *ServiceEntryApplyConfiguration {
+func (b *ServiceEntryApplyConfiguration) WithStatus(value v1alpha3.ServiceEntryStatus) *ServiceEntryApplyConfiguration {
 	b.Status = &value
 	return b
 }

--- a/pkg/applyconfiguration/networking/v1alpha3/serviceentry.go
+++ b/pkg/applyconfiguration/networking/v1alpha3/serviceentry.go
@@ -17,7 +17,6 @@
 package v1alpha3
 
 import (
-	v1alpha1 "istio.io/api/meta/v1alpha1"
 	v1alpha3 "istio.io/api/networking/v1alpha3"
 	v1 "istio.io/client-go/pkg/applyconfiguration/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,8 +28,8 @@ import (
 type ServiceEntryApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	Spec                             *v1alpha3.ServiceEntry `json:"spec,omitempty"`
-	Status                           *v1alpha1.IstioStatus  `json:"status,omitempty"`
+	Spec                             *v1alpha3.ServiceEntry       `json:"spec,omitempty"`
+	Status                           *v1alpha3.ServiceEntryStatus `json:"status,omitempty"`
 }
 
 // ServiceEntry constructs an declarative configuration of the ServiceEntry type for use with
@@ -213,7 +212,7 @@ func (b *ServiceEntryApplyConfiguration) WithSpec(value v1alpha3.ServiceEntry) *
 // WithStatus sets the Status field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Status field is set to the value of the last call.
-func (b *ServiceEntryApplyConfiguration) WithStatus(value v1alpha1.IstioStatus) *ServiceEntryApplyConfiguration {
+func (b *ServiceEntryApplyConfiguration) WithStatus(value v1alpha3.ServiceEntryStatus) *ServiceEntryApplyConfiguration {
 	b.Status = &value
 	return b
 }

--- a/pkg/applyconfiguration/networking/v1beta1/serviceentry.go
+++ b/pkg/applyconfiguration/networking/v1beta1/serviceentry.go
@@ -17,7 +17,6 @@
 package v1beta1
 
 import (
-	v1alpha1 "istio.io/api/meta/v1alpha1"
 	v1alpha3 "istio.io/api/networking/v1alpha3"
 	v1 "istio.io/client-go/pkg/applyconfiguration/meta/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -29,8 +28,8 @@ import (
 type ServiceEntryApplyConfiguration struct {
 	v1.TypeMetaApplyConfiguration    `json:",inline"`
 	*v1.ObjectMetaApplyConfiguration `json:"metadata,omitempty"`
-	Spec                             *v1alpha3.ServiceEntry `json:"spec,omitempty"`
-	Status                           *v1alpha1.IstioStatus  `json:"status,omitempty"`
+	Spec                             *v1alpha3.ServiceEntry       `json:"spec,omitempty"`
+	Status                           *v1alpha3.ServiceEntryStatus `json:"status,omitempty"`
 }
 
 // ServiceEntry constructs an declarative configuration of the ServiceEntry type for use with
@@ -213,7 +212,7 @@ func (b *ServiceEntryApplyConfiguration) WithSpec(value v1alpha3.ServiceEntry) *
 // WithStatus sets the Status field in the declarative configuration to the given value
 // and returns the receiver, so that objects can be built by chaining "With" function invocations.
 // If called multiple times, the Status field is set to the value of the last call.
-func (b *ServiceEntryApplyConfiguration) WithStatus(value v1alpha1.IstioStatus) *ServiceEntryApplyConfiguration {
+func (b *ServiceEntryApplyConfiguration) WithStatus(value v1alpha3.ServiceEntryStatus) *ServiceEntryApplyConfiguration {
 	b.Status = &value
 	return b
 }


### PR DESCRIPTION
run make gen with the newest kubegen tool updates which consume api comments to use the new ServiceEntryStatus

doesn't seem like it should be necessary but automation didn't seem to handle the `make gen` for some reason so I ran it manually.