### PR TITLE
remove GODEBUG=gotypesalias=0 workaround from generate-k8s-client

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
   "name": "istio build-tools",
-  "image": "registry.istio.io/testing/build-tools:master-344978549023107b14c57d2ef8523d41b82ccc76",
+  "image": "registry.istio.io/testing/build-tools:master-80657d56e324b5d8b4a74806bf0979e4b89e99a5",
   "privileged": true,
   "remoteEnv": {
     "USE_GKE_GCLOUD_AUTH_PLUGIN": "True",

--- a/Makefile.core.mk
+++ b/Makefile.core.mk
@@ -109,8 +109,7 @@ fixup_generated_files=\
 .PHONY: generate-k8s-client
 generate-k8s-client:
 	# generate kube api type wrappers for istio types
-	# TODO(https://github.com/istio/istio/issues/54831) do not depend on gotypesalias=0 for this to work
-	@GODEBUG=gotypesalias=0 $(kubetype_gen) --input-dirs $(kube_istio_source_packages) --output-package $(kube_api_base_package) -h $(kube_go_header_text)
+	@$(kubetype_gen) --input-dirs $(kube_istio_source_packages) --output-package $(kube_api_base_package) -h $(kube_go_header_text)
 	@$(move_generated)
 	# generate deepcopy for kube api types
 	@$(deepcopy_gen) --input-dirs $(kube_api_packages) -O zz_generated.deepcopy  -h $(kube_go_header_text)

--- a/common/scripts/setup_env.sh
+++ b/common/scripts/setup_env.sh
@@ -77,7 +77,7 @@ fi
 TOOLS_REGISTRY_PROVIDER=${TOOLS_REGISTRY_PROVIDER:-registry.istio.io}
 PROJECT_ID=${PROJECT_ID:-testing}
 if [[ "${IMAGE_VERSION:-}" == "" ]]; then
-  IMAGE_VERSION=master-344978549023107b14c57d2ef8523d41b82ccc76
+  IMAGE_VERSION=master-80657d56e324b5d8b4a74806bf0979e4b89e99a5
 fi
 if [[ "${IMAGE_NAME:-}" == "" ]]; then
   IMAGE_NAME=build-tools

--- a/pkg/apis/extensions/v1alpha1/register.gen.go
+++ b/pkg/apis/extensions/v1alpha1/register.gen.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	// Package-wide variables from generator "register".
+	// Package-wide variables from generator "register.go".
 	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1alpha1"}
 	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes)
 	localSchemeBuilder = &SchemeBuilder
@@ -31,7 +31,7 @@ var (
 )
 
 const (
-	// Package-wide consts from generator "register".
+	// Package-wide consts from generator "register.go".
 	GroupName = "extensions.istio.io"
 )
 

--- a/pkg/apis/extensions/v1alpha1/types.gen.go
+++ b/pkg/apis/extensions/v1alpha1/types.gen.go
@@ -22,7 +22,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // <!-- crd generation tags
@@ -70,7 +69,6 @@ type TrafficExtensionList struct {
 	Items       []*TrafficExtension `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // WasmPlugin provides a mechanism to extend the functionality provided by

--- a/pkg/apis/networking/v1/register.gen.go
+++ b/pkg/apis/networking/v1/register.gen.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	// Package-wide variables from generator "register".
+	// Package-wide variables from generator "register.go".
 	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1"}
 	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes)
 	localSchemeBuilder = &SchemeBuilder
@@ -31,7 +31,7 @@ var (
 )
 
 const (
-	// Package-wide consts from generator "register".
+	// Package-wide consts from generator "register.go".
 	GroupName = "networking.istio.io"
 )
 

--- a/pkg/apis/networking/v1/types.gen.go
+++ b/pkg/apis/networking/v1/types.gen.go
@@ -22,7 +22,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // DestinationRule defines policies that apply to traffic intended for a service
@@ -72,7 +71,6 @@ type DestinationRuleList struct {
 	Items           []*DestinationRule `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Gateway describes a load balancer operating at the edge of the mesh
@@ -117,7 +115,6 @@ type GatewayList struct {
 	Items           []*Gateway `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ServiceEntry enables adding additional entries into Istio's internal
@@ -177,7 +174,6 @@ type ServiceEntryList struct {
 	Items           []*ServiceEntry `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // `Sidecar` describes the configuration of the sidecar proxy that mediates
@@ -223,7 +219,6 @@ type SidecarList struct {
 	Items           []*Sidecar `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Configuration affecting traffic routing.
@@ -274,7 +269,6 @@ type VirtualServiceList struct {
 	Items           []*VirtualService `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // WorkloadEntry enables specifying the properties of a single non-Kubernetes workload such a VM or a bare metal services that can be referred to by service entries.
@@ -326,7 +320,6 @@ type WorkloadEntryList struct {
 	Items           []*WorkloadEntry `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // `WorkloadGroup` enables specifying the properties of a single workload for bootstrap and

--- a/pkg/apis/networking/v1alpha3/register.gen.go
+++ b/pkg/apis/networking/v1alpha3/register.gen.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	// Package-wide variables from generator "register".
+	// Package-wide variables from generator "register.go".
 	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1alpha3"}
 	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes)
 	localSchemeBuilder = &SchemeBuilder
@@ -31,7 +31,7 @@ var (
 )
 
 const (
-	// Package-wide consts from generator "register".
+	// Package-wide consts from generator "register.go".
 	GroupName = "networking.istio.io"
 )
 

--- a/pkg/apis/networking/v1alpha3/types.gen.go
+++ b/pkg/apis/networking/v1alpha3/types.gen.go
@@ -22,7 +22,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // DestinationRule defines policies that apply to traffic intended for a service
@@ -72,7 +71,6 @@ type DestinationRuleList struct {
 	Items       []*DestinationRule `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // EnvoyFilter provides a mechanism to customize the Envoy configuration
@@ -120,7 +118,6 @@ type EnvoyFilterList struct {
 	Items       []*EnvoyFilter `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Gateway describes a load balancer operating at the edge of the mesh
@@ -165,7 +162,6 @@ type GatewayList struct {
 	Items       []*Gateway `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ServiceEntry enables adding additional entries into Istio's internal
@@ -225,7 +221,6 @@ type ServiceEntryList struct {
 	Items       []*ServiceEntry `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // `Sidecar` describes the configuration of the sidecar proxy that mediates
@@ -271,7 +266,6 @@ type SidecarList struct {
 	Items       []*Sidecar `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Configuration affecting traffic routing.
@@ -322,7 +316,6 @@ type VirtualServiceList struct {
 	Items       []*VirtualService `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // WorkloadEntry enables specifying the properties of a single non-Kubernetes workload such a VM or a bare metal services that can be referred to by service entries.
@@ -374,7 +367,6 @@ type WorkloadEntryList struct {
 	Items       []*WorkloadEntry `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // `WorkloadGroup` enables specifying the properties of a single workload for bootstrap and

--- a/pkg/apis/networking/v1beta1/register.gen.go
+++ b/pkg/apis/networking/v1beta1/register.gen.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	// Package-wide variables from generator "register".
+	// Package-wide variables from generator "register.go".
 	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1beta1"}
 	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes)
 	localSchemeBuilder = &SchemeBuilder
@@ -31,7 +31,7 @@ var (
 )
 
 const (
-	// Package-wide consts from generator "register".
+	// Package-wide consts from generator "register.go".
 	GroupName = "networking.istio.io"
 )
 

--- a/pkg/apis/networking/v1beta1/types.gen.go
+++ b/pkg/apis/networking/v1beta1/types.gen.go
@@ -23,7 +23,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // DestinationRule defines policies that apply to traffic intended for a service
@@ -73,7 +72,6 @@ type DestinationRuleList struct {
 	Items       []*DestinationRule `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Gateway describes a load balancer operating at the edge of the mesh
@@ -118,7 +116,6 @@ type GatewayList struct {
 	Items       []*Gateway `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // `ProxyConfig` exposes proxy level configuration options.
@@ -164,7 +161,6 @@ type ProxyConfigList struct {
 	Items       []*ProxyConfig `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // ServiceEntry enables adding additional entries into Istio's internal
@@ -224,7 +220,6 @@ type ServiceEntryList struct {
 	Items       []*ServiceEntry `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // `Sidecar` describes the configuration of the sidecar proxy that mediates
@@ -270,7 +265,6 @@ type SidecarList struct {
 	Items       []*Sidecar `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // Configuration affecting traffic routing.
@@ -321,7 +315,6 @@ type VirtualServiceList struct {
 	Items       []*VirtualService `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // WorkloadEntry enables specifying the properties of a single non-Kubernetes workload such a VM or a bare metal services that can be referred to by service entries.
@@ -373,7 +366,6 @@ type WorkloadEntryList struct {
 	Items       []*WorkloadEntry `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // `WorkloadGroup` enables specifying the properties of a single workload for bootstrap and

--- a/pkg/apis/security/v1/register.gen.go
+++ b/pkg/apis/security/v1/register.gen.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	// Package-wide variables from generator "register".
+	// Package-wide variables from generator "register.go".
 	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1"}
 	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes)
 	localSchemeBuilder = &SchemeBuilder
@@ -31,7 +31,7 @@ var (
 )
 
 const (
-	// Package-wide consts from generator "register".
+	// Package-wide consts from generator "register.go".
 	GroupName = "security.istio.io"
 )
 

--- a/pkg/apis/security/v1/types.gen.go
+++ b/pkg/apis/security/v1/types.gen.go
@@ -22,7 +22,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // AuthorizationPolicy enables access control on workloads.
@@ -73,7 +72,6 @@ type AuthorizationPolicyList struct {
 	Items           []*AuthorizationPolicy `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // <!-- crd generation tags
@@ -122,7 +120,6 @@ type PeerAuthenticationList struct {
 	Items           []*PeerAuthentication `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // <!-- crd generation tags

--- a/pkg/apis/security/v1beta1/register.gen.go
+++ b/pkg/apis/security/v1beta1/register.gen.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	// Package-wide variables from generator "register".
+	// Package-wide variables from generator "register.go".
 	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1beta1"}
 	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes)
 	localSchemeBuilder = &SchemeBuilder
@@ -31,7 +31,7 @@ var (
 )
 
 const (
-	// Package-wide consts from generator "register".
+	// Package-wide consts from generator "register.go".
 	GroupName = "security.istio.io"
 )
 

--- a/pkg/apis/security/v1beta1/types.gen.go
+++ b/pkg/apis/security/v1beta1/types.gen.go
@@ -22,7 +22,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // AuthorizationPolicy enables access control on workloads.
@@ -73,7 +72,6 @@ type AuthorizationPolicyList struct {
 	Items       []*AuthorizationPolicy `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // <!-- crd generation tags
@@ -122,7 +120,6 @@ type PeerAuthenticationList struct {
 	Items       []*PeerAuthentication `json:"items" protobuf:"bytes,2,rep,name=items"`
 }
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // <!-- crd generation tags

--- a/pkg/apis/telemetry/v1/register.gen.go
+++ b/pkg/apis/telemetry/v1/register.gen.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	// Package-wide variables from generator "register".
+	// Package-wide variables from generator "register.go".
 	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1"}
 	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes)
 	localSchemeBuilder = &SchemeBuilder
@@ -31,7 +31,7 @@ var (
 )
 
 const (
-	// Package-wide consts from generator "register".
+	// Package-wide consts from generator "register.go".
 	GroupName = "telemetry.istio.io"
 )
 

--- a/pkg/apis/telemetry/v1/types.gen.go
+++ b/pkg/apis/telemetry/v1/types.gen.go
@@ -22,7 +22,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // <!-- crd generation tags

--- a/pkg/apis/telemetry/v1alpha1/register.gen.go
+++ b/pkg/apis/telemetry/v1alpha1/register.gen.go
@@ -23,7 +23,7 @@ import (
 )
 
 var (
-	// Package-wide variables from generator "register".
+	// Package-wide variables from generator "register.go".
 	SchemeGroupVersion = schema.GroupVersion{Group: GroupName, Version: "v1alpha1"}
 	SchemeBuilder      = runtime.NewSchemeBuilder(addKnownTypes)
 	localSchemeBuilder = &SchemeBuilder
@@ -31,7 +31,7 @@ var (
 )
 
 const (
-	// Package-wide consts from generator "register".
+	// Package-wide consts from generator "register.go".
 	GroupName = "telemetry.istio.io"
 )
 

--- a/pkg/apis/telemetry/v1alpha1/types.gen.go
+++ b/pkg/apis/telemetry/v1alpha1/types.gen.go
@@ -22,7 +22,6 @@ import (
 	v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-//
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // <!-- crd generation tags


### PR DESCRIPTION
Related to https://github.com/istio/istio/issues/54831

kubetype-gen has been migrated to k8s.io/gengo/v2, which handles Go 1.27 types natively. Removing the workaround that is not needed


Depend on new image generated after this merge: https://github.com/istio/tools/pull/3474